### PR TITLE
change requests version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ PySocks==1.7.1
 python-dotenv==0.14.0
 python-engineio==3.13.2
 python-socketio==4.6.0
-requests==2.24.0
+requests==2.11.1
 requests-oauthlib==1.3.0
 rfc3987==1.3.8
 six==1.15.0


### PR DESCRIPTION
- Changed the dependency version for requests because pyrebase 3.0.27 depends on requests==2.11.1